### PR TITLE
Define and structure llm prompts for data extraction

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,0 +1,1 @@
+# llm package

--- a/llm/parsers.py
+++ b/llm/parsers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+
+def parse_extraction_response(
+    response_string: str,
+    category_definitions: Dict[str, str],
+    structured_data_definition: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    try:
+        data = json.loads(response_string)
+        expected_keys = list(category_definitions.keys())
+        if structured_data_definition and "output_key_for_structured" in structured_data_definition:
+            expected_keys.append(structured_data_definition["output_key_for_structured"])
+        for key in expected_keys:
+            if key not in data:
+                # Keep non-fatal; warn via print to avoid raising in UI contexts
+                print(f"Warning: Expected key '{key}' not found in LLM response.")
+        return data
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e}")
+        return None
+
+
+def parse_processed_list_response(response_string: str) -> Optional[Dict[str, Any]]:
+    try:
+        data = json.loads(response_string)
+        return data
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e}")
+        return None
+
+
+def parse_comparison_response(response_string: str) -> Optional[Dict[str, Any]]:
+    try:
+        data = json.loads(response_string)
+        return data
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e}")
+        return None

--- a/llm/perplexity_client.py
+++ b/llm/perplexity_client.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+import json
+from typing import Any, Dict, List, Optional
+
+import requests
+
+DEFAULT_PPLX_URL = "https://api.perplexity.ai/chat/completions"
+DEFAULT_MODEL = "sonar-pro"
+
+
+class PerplexityClient:
+    """Lightweight client for Perplexity Chat Completions API.
+
+    Notes:
+    - API key is read from env var PERPLEXITY_API_KEY unless explicitly passed.
+    - Returns raw text content by default; caller is responsible for JSON parsing.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_url: str = DEFAULT_PPLX_URL,
+        model: str = DEFAULT_MODEL,
+        timeout_seconds: int = 60,
+    ) -> None:
+        self.api_key = api_key or os.getenv("PERPLEXITY_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "PERPLEXITY_API_KEY is required. Set env var or pass api_key explicitly."
+            )
+        self.api_url = api_url
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+
+    def chat(
+        self,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        max_tokens: Optional[int] = None,
+        response_format: Optional[Dict[str, Any]] = None,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Call Perplexity chat completions.
+
+        Returns the full JSON response from the API.
+        """
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "top_p": top_p,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if response_format is not None:
+            payload["response_format"] = response_format
+        if extra:
+            payload.update(extra)
+
+        resp = requests.post(
+            self.api_url, headers=headers, json=payload, timeout=self.timeout_seconds
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    @staticmethod
+    def extract_text(response: Dict[str, Any]) -> str:
+        """Extract assistant message content from a Perplexity response."""
+        try:
+            return response["choices"][0]["message"]["content"]
+        except Exception:
+            return ""

--- a/llm/prompts.py
+++ b/llm/prompts.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+# Prompt Template 1: Entity Extraction Plaintext
+
+def build_p1_entity_extraction_prompt(
+    input_text_variable_name: str,
+    input_text: str,
+    category_definitions_variable_name: str,
+    category_definitions_json: Dict[str, str],
+    input_metadata_variable_name: Optional[str] = None,
+    input_metadata: Optional[str] = None,
+    structured_data_definition_variable_name: Optional[str] = None,
+    structured_data_definition_json: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Builds the P1 prompt string.
+
+    The final output must be a single JSON object per the template instructions.
+    """
+    lines: List[str] = []
+    lines.append("TASK: Please analyze the provided -{{input_text_variable_name}} and any accompanying -{{input_metadata_variable_name}}.\n")
+    lines.append(
+        "Your goal is to extract specific types of information and structure it as a JSON object.\n"
+    )
+    lines.append(
+        "Using the definitions provided in -{{category_definitions_variable_name}}, identify and list items for each defined category. The keys in your output JSON for these lists should match the 'output_key_for_list_X' values in -{{category_definitions_variable_name}}. Each list should contain unique string values.\n"
+    )
+    lines.append(
+        "Additionally, if -{{structured_data_definition_variable_name}} is provided, extract detailed structured information matching its definition. The key in your output JSON for this structured data should match the 'output_key_for_structured' in -{{structured_data_definition_variable_name}}. The value should be a list of objects, where each object's structure is guided by 'fields_description'.\n"
+    )
+    lines.append("The final output must be a single JSON object.\n\n")
+
+    # Inject dynamic variables
+    lines.append(f"-{input_text_variable_name}:\n<{input_text}>\n")
+
+    if input_metadata_variable_name:
+        meta = input_metadata or ""
+        lines.append(f"-{input_metadata_variable_name}: (if applicable)\n<{meta}>\n")
+
+    lines.append(f"-{category_definitions_variable_name}:\n<{category_definitions_json}>\n")
+
+    if structured_data_definition_variable_name and structured_data_definition_json is not None:
+        lines.append(
+            f"-{structured_data_definition_variable_name}: (if applicable)\n<{structured_data_definition_json}>\n"
+        )
+
+    return "".join(lines)
+
+
+# Prompt Template 2: Processing Extracted List Plaintext
+
+def build_p2_process_list_prompt(
+    input_list_variable_name: str,
+    input_list: List[str],
+    list_item_category_name: str,
+    processing_task_description: str,
+    output_format_description: str,
+) -> str:
+    lines: List[str] = []
+    lines.append(
+        f"TASK: You have received a list of items identified as -{{list_item_category_name}}:\n\n"
+    )
+    lines.append(f"-{input_list_variable_name}:\n<{input_list}>\n\n")
+    lines.append("Your task is to perform the following operation as described in -{{processing_task_description}}:\n\n")
+    lines.append(f"<{processing_task_description}>\n\n")
+    lines.append("Please provide the output in the format described in -{{output_format_description}}:\n\n")
+    lines.append(f"<{output_format_description}>\n")
+    return "".join(lines)
+
+
+# Prompt Template 3: Comparing Two Sets of Extracted Entities
+
+def build_p3_compare_sets_prompt(
+    entity_set_A_variable_name: str,
+    entity_set_A: Dict[str, Any],
+    entity_set_B_variable_name: str,
+    entity_set_B: Dict[str, Any],
+    categories_to_compare_variable_name: str,
+    categories_to_compare: List[str],
+    comparison_criteria_variable_name: str,
+    comparison_criteria: str,
+    output_format_description_comparison: str,
+) -> str:
+    lines: List[str] = []
+    lines.append("TASK: You are provided with two sets of extracted entities:\n\n")
+    lines.append(f"Set A (-{{{entity_set_A_variable_name}}}):\n<{entity_set_A}>\n\n")
+    lines.append(f"Set B (-{{{entity_set_B_variable_name}}}):\n<{entity_set_B}>\n\n")
+    lines.append(
+        "Your objective is to compare these two sets. Focus your comparison on the categories specified in -{{categories_to_compare_variable_name}}:\n\n"
+    )
+    lines.append(f"<{categories_to_compare}>\n\n")
+    lines.append(
+        "Follow the comparison instructions outlined in -{{comparison_criteria_variable_name}}:\n\n"
+    )
+    lines.append(f"<{comparison_criteria}>\n\n")
+    lines.append(
+        "Present your comparison results in the JSON format described in -{{output_format_description_comparison}}:\n\n"
+    )
+    lines.append(f"<{output_format_description_comparison}>\n")
+    return "".join(lines)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit
+requests>=2.31.0,<3

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,337 @@
+import os
+import json
+from typing import Any, Dict, List, Optional
+
 import streamlit as st
 
-st.title("🎈 My new app")
-st.write(
-    "Let's start building! For help and inspiration, head over to [docs.streamlit.io](https://docs.streamlit.io/)."
+from llm.perplexity_client import PerplexityClient
+from llm.prompts import (
+    build_p1_entity_extraction_prompt,
+    build_p2_process_list_prompt,
+    build_p3_compare_sets_prompt,
 )
+from llm.parsers import (
+    parse_extraction_response,
+    parse_processed_list_response,
+    parse_comparison_response,
+)
+
+
+st.set_page_config(page_title="OPF Prompt Runner", page_icon="🧩", layout="wide")
+st.title("🧩 Official Prompt Framework (OPF) — Prompt Runner")
+
+
+@st.cache_data
+def get_default_category_definitions() -> Dict[str, str]:
+    return {
+        "Unique_Subjects": "Distinct subjects or primary topics mentioned.",
+        "Unique_Elements": "Specific components or individual items identified.",
+    }
+
+
+def ensure_client() -> Optional[PerplexityClient]:
+    try:
+        return PerplexityClient()
+    except Exception as e:
+        st.warning(
+            "Perplexity client is not configured. Set env var PERPLEXITY_API_KEY to enable API calls."
+        )
+        st.caption(str(e))
+        return None
+
+
+with st.sidebar:
+    st.header("Perplexity Settings")
+    pplx_key = st.text_input(
+        "PERPLEXITY_API_KEY",
+        value=os.getenv("PERPLEXITY_API_KEY", ""),
+        type="password",
+        help="Not stored. Used only for this session.",
+    )
+    model = st.text_input("Model", value="sonar-pro")
+    api_url = st.text_input(
+        "API URL", value="https://api.perplexity.ai/chat/completions"
+    )
+    temperature = st.slider("Temperature", 0.0, 1.0, 0.0, 0.1)
+    top_p = st.slider("top_p", 0.0, 1.0, 1.0, 0.05)
+    max_tokens = st.number_input("max_tokens (optional)", min_value=0, value=0)
+
+    enable_calls = st.checkbox("Enable API calls", value=False)
+
+
+tab1, tab2, tab3 = st.tabs([
+    "P1 — Entity Extraction",
+    "P2 — Process List",
+    "P3 — Compare Sets",
+])
+
+
+with tab1:
+    st.subheader("P1 — Entity Extraction Plaintext")
+    input_text_variable_name = st.text_input(
+        "Input text variable name", value="input_text"
+    )
+    input_text = st.text_area("Input text", height=180)
+
+    input_metadata_variable_name = st.text_input(
+        "Input metadata variable name (optional)", value="input_metadata"
+    )
+    input_metadata = st.text_area("Input metadata (optional)", height=100)
+
+    category_definitions_variable_name = st.text_input(
+        "Category definitions variable name", value="category_definitions"
+    )
+    category_defs_default = json.dumps(get_default_category_definitions())
+    category_definitions_json_text = st.text_area(
+        "Category definitions JSON", value=category_defs_default, height=160
+    )
+
+    structured_data_definition_variable_name = st.text_input(
+        "Structured data definition variable name (optional)",
+        value="structured_data_definition",
+    )
+    structured_data_definition_json_text = st.text_area(
+        "Structured data definition JSON (optional)", value="", height=140
+    )
+
+    gen_p1 = st.button("Build P1 prompt")
+    if gen_p1:
+        try:
+            category_definitions_json = json.loads(category_definitions_json_text or "{}")
+        except json.JSONDecodeError as e:
+            st.error(f"Invalid category definitions JSON: {e}")
+            category_definitions_json = {}
+
+        structured_def_json = None
+        if structured_data_definition_json_text.strip():
+            try:
+                structured_def_json = json.loads(structured_data_definition_json_text)
+            except json.JSONDecodeError as e:
+                st.error(f"Invalid structured definition JSON: {e}")
+
+        prompt_text = build_p1_entity_extraction_prompt(
+            input_text_variable_name=input_text_variable_name,
+            input_text=input_text,
+            category_definitions_variable_name=category_definitions_variable_name,
+            category_definitions_json=category_definitions_json,
+            input_metadata_variable_name=(
+                input_metadata_variable_name or None
+            ),
+            input_metadata=(input_metadata or None),
+            structured_data_definition_variable_name=(
+                structured_data_definition_variable_name or None
+            ),
+            structured_data_definition_json=structured_def_json,
+        )
+        st.code(prompt_text)
+
+    st.divider()
+    st.caption("Call Perplexity (expects JSON-only output)")
+    call_p1 = st.button("Run P1 via Perplexity")
+    if call_p1 and enable_calls:
+        os.environ["PERPLEXITY_API_KEY"] = pplx_key
+        try:
+            category_definitions_json = json.loads(category_definitions_json_text or "{}")
+        except json.JSONDecodeError as e:
+            st.error(f"Invalid category definitions JSON: {e}")
+            category_definitions_json = {}
+        structured_def_json = None
+        if structured_data_definition_json_text.strip():
+            try:
+                structured_def_json = json.loads(structured_data_definition_json_text)
+            except json.JSONDecodeError as e:
+                st.error(f"Invalid structured definition JSON: {e}")
+
+        prompt_text = build_p1_entity_extraction_prompt(
+            input_text_variable_name=input_text_variable_name,
+            input_text=input_text,
+            category_definitions_variable_name=category_definitions_variable_name,
+            category_definitions_json=category_definitions_json,
+            input_metadata_variable_name=(
+                input_metadata_variable_name or None
+            ),
+            input_metadata=(input_metadata or None),
+            structured_data_definition_variable_name=(
+                structured_data_definition_variable_name or None
+            ),
+            structured_data_definition_json=structured_def_json,
+        )
+        client = PerplexityClient(api_key=pplx_key, api_url=api_url, model=model)
+        response = client.chat(
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant that returns JSON only."},
+                {"role": "user", "content": prompt_text},
+            ],
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens or None,
+            response_format={"type": "json_object"},
+        )
+        text = client.extract_text(response)
+        st.text_area("Raw response", value=text, height=200)
+        parsed = parse_extraction_response(
+            text, category_definitions=category_definitions_json, structured_data_definition=structured_def_json
+        )
+        st.json(parsed or {})
+
+
+with tab2:
+    st.subheader("P2 — Process Extracted List")
+    list_item_category_name = st.text_input(
+        "List item category name", value="Unique_Subjects"
+    )
+    input_list_variable_name = st.text_input("Input list variable name", value="input_list")
+    input_list_text = st.text_area(
+        "Input list JSON (e.g. [\"A\", \"B\"])", value="[]", height=120
+    )
+    processing_task_description = st.text_area(
+        "Processing task description", value="Describe each item in one sentence.", height=100
+    )
+    output_format_description = st.text_area(
+        "Output format description",
+        value='{"described_items":[{"item": "...","description":"..."}]}',
+        height=100,
+    )
+    gen_p2 = st.button("Build P2 prompt")
+    if gen_p2:
+        try:
+            input_list = json.loads(input_list_text)
+            prompt_text = build_p2_process_list_prompt(
+                input_list_variable_name=input_list_variable_name,
+                input_list=input_list,
+                list_item_category_name=list_item_category_name,
+                processing_task_description=processing_task_description,
+                output_format_description=output_format_description,
+            )
+            st.code(prompt_text)
+        except json.JSONDecodeError as e:
+            st.error(f"Invalid input list JSON: {e}")
+
+    st.divider()
+    call_p2 = st.button("Run P2 via Perplexity")
+    if call_p2 and enable_calls:
+        os.environ["PERPLEXITY_API_KEY"] = pplx_key
+        try:
+            input_list = json.loads(input_list_text)
+        except json.JSONDecodeError as e:
+            st.error(f"Invalid input list JSON: {e}")
+            input_list = []
+
+        prompt_text = build_p2_process_list_prompt(
+            input_list_variable_name=input_list_variable_name,
+            input_list=input_list,
+            list_item_category_name=list_item_category_name,
+            processing_task_description=processing_task_description,
+            output_format_description=output_format_description,
+        )
+        client = PerplexityClient(api_key=pplx_key, api_url=api_url, model=model)
+        response = client.chat(
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant that returns JSON only."},
+                {"role": "user", "content": prompt_text},
+            ],
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens or None,
+            response_format={"type": "json_object"},
+        )
+        text = client.extract_text(response)
+        st.text_area("Raw response", value=text, height=200)
+        parsed = parse_processed_list_response(text)
+        st.json(parsed or {})
+
+
+with tab3:
+    st.subheader("P3 — Compare Entity Sets")
+    entity_set_A_variable_name = st.text_input(
+        "Entity set A variable name", value="entity_set_A"
+    )
+    entity_set_A_text = st.text_area("Entity set A JSON", value="{}", height=140)
+    entity_set_B_variable_name = st.text_input(
+        "Entity set B variable name", value="entity_set_B"
+    )
+    entity_set_B_text = st.text_area("Entity set B JSON", value="{}", height=140)
+    categories_to_compare_variable_name = st.text_input(
+        "Categories to compare variable name", value="categories_to_compare"
+    )
+    categories_to_compare_text = st.text_input(
+        "Categories to compare JSON list", value='["Unique_Subjects", "Unique_Elements"]'
+    )
+    comparison_criteria_variable_name = st.text_input(
+        "Comparison criteria variable name", value="comparison_criteria"
+    )
+    comparison_criteria = st.text_area(
+        "Comparison criteria",
+        value=(
+            "For each category, identify common items, items only in A, items only in B, "
+            "and compute a Jaccard similarity index if applicable."
+        ),
+        height=120,
+    )
+    output_format_description_comparison = st.text_area(
+        "Output format description",
+        value=(
+            '{"<category>": {"common_items": [], "items_only_in_A": [], "items_only_in_B": [], "similarity_jaccard_index": 0.0}}'
+        ),
+        height=120,
+    )
+    gen_p3 = st.button("Build P3 prompt")
+    if gen_p3:
+        try:
+            entity_set_A = json.loads(entity_set_A_text or "{}")
+            entity_set_B = json.loads(entity_set_B_text or "{}")
+            categories_to_compare = json.loads(categories_to_compare_text or "[]")
+        except json.JSONDecodeError as e:
+            st.error(f"Invalid JSON: {e}")
+        else:
+            prompt_text = build_p3_compare_sets_prompt(
+                entity_set_A_variable_name=entity_set_A_variable_name,
+                entity_set_A=entity_set_A,
+                entity_set_B_variable_name=entity_set_B_variable_name,
+                entity_set_B=entity_set_B,
+                categories_to_compare_variable_name=categories_to_compare_variable_name,
+                categories_to_compare=categories_to_compare,
+                comparison_criteria_variable_name=comparison_criteria_variable_name,
+                comparison_criteria=comparison_criteria,
+                output_format_description_comparison=output_format_description_comparison,
+            )
+            st.code(prompt_text)
+
+    st.divider()
+    call_p3 = st.button("Run P3 via Perplexity")
+    if call_p3 and enable_calls:
+        os.environ["PERPLEXITY_API_KEY"] = pplx_key
+        try:
+            entity_set_A = json.loads(entity_set_A_text or "{}")
+            entity_set_B = json.loads(entity_set_B_text or "{}")
+            categories_to_compare = json.loads(categories_to_compare_text or "[]")
+        except json.JSONDecodeError as e:
+            st.error(f"Invalid JSON: {e}")
+        else:
+            prompt_text = build_p3_compare_sets_prompt(
+                entity_set_A_variable_name=entity_set_A_variable_name,
+                entity_set_A=entity_set_A,
+                entity_set_B_variable_name=entity_set_B_variable_name,
+                entity_set_B=entity_set_B,
+                categories_to_compare_variable_name=categories_to_compare_variable_name,
+                categories_to_compare=categories_to_compare,
+                comparison_criteria_variable_name=comparison_criteria_variable_name,
+                comparison_criteria=comparison_criteria,
+                output_format_description_comparison=output_format_description_comparison,
+            )
+            client = PerplexityClient(api_key=pplx_key, api_url=api_url, model=model)
+            response = client.chat(
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant that returns JSON only."},
+                    {"role": "user", "content": prompt_text},
+                ],
+                temperature=temperature,
+                top_p=top_p,
+                max_tokens=max_tokens or None,
+                response_format={"type": "json_object"},
+            )
+            text = PerplexityClient.extract_text(response)
+            st.text_area("Raw response", value=text, height=200)
+            parsed = parse_comparison_response(text)
+            st.json(parsed or {})
+


### PR DESCRIPTION
Implement OPF prompt templates (P1, P2, P3) and a Perplexity client, integrating them into a Streamlit UI for prompt generation, API calls, and response parsing.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c4af726-0923-46d7-abcf-b8b683d1e785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c4af726-0923-46d7-abcf-b8b683d1e785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

